### PR TITLE
Feature getChannelLive and getChannelPastLive

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,64 @@ const channel = await ytubes.getChannel('Hungria Hip Hop')
   ```
 </details>
 
+### getChannelLive(channelId, options)
+
+Returns all the live streams of a specific channel
+
+```js
+const lives = await ytubes.getChannelLive('UCSJ4gkVC6NrvII8umztf0Ow')
+```
+
+<details>
+  <summary>Output</summary>
+
+  ```js
+  [
+    {
+      id: '5qap5aO4i9A',
+      type: 'live',
+      live: true,
+      title: 'lofi hip hop radio - beats to relax/study to',
+      link: 'https://www.youtube.com/watch?v=5qap5aO4i9A',
+      views: 25488,
+      shareLink: 'https://youtu.be/5qap5aO4i9A',
+      channel: 'https://www.youtube.com/channel/UCSJ4gkVC6NrvII8umztf0Ow',
+      thumbnail: 'https://i.ytimg.com/vi/5qap5aO4i9A/maxresdefault.jpg'
+    },
+    ...
+  ]
+  ```
+</details>
+
+### getChannelPastLive(channelId, options)
+
+Returns all the past live streams of a specific channel
+
+```js
+const lives = await ytubes.getChannelPastLive('UCXBE_QQSZueB8082ml5fslg')
+```
+
+<details>
+  <summary>Output</summary>
+
+  ```js
+  [
+    {
+      id: 'cilUevUhZfw',
+      type: 'live',
+      live: false,
+      title: 'TIMTHETATMAN RETURNS TO FORTNITE FT NINJA, MARSHMELLO & SYPHERPK',
+      link: 'https://www.youtube.com/watch?v=cilUevUhZfw',
+      views: 711695,
+      shareLink: 'https://youtu.be/cilUevUhZfw',
+      channel: 'https://www.youtube.com/channel/UCXBE_QQSZueB8082ml5fslg',
+      thumbnail: 'https://i.ytimg.com/vi/cilUevUhZfw/maxresdefault.jpg'
+    },
+    ...
+  ]
+  ```
+</details>
+
 ### getMovie(query, options)
 
 Returns the details of all movies found
@@ -166,8 +224,10 @@ const live = await ytubes.getLive('Coding in Chicago')
     {
       id: 'esX7SFtEjHg',
       type: 'live',
+      live: true,
       title: 'Coding in Chicago | 🎧  LoFi Jazz Hip-Hop [Code - Relax - Study]',
       link: 'https://www.youtube.com/watch?v=esX7SFtEjHg',
+      views: 142,
       shareLink: 'https://youtu.be/esX7SFtEjHg',
       channel: 'https://www.youtube.com/channel/UC9rvsIHgzuiwTQ-yi0Qj2Mw',
       thumbnail: 'https://i.ytimg.com/vi/esX7SFtEjHg/maxresdefault.jpg'

--- a/src/constants/default.ts
+++ b/src/constants/default.ts
@@ -9,6 +9,7 @@ export const headers = {
 export const searchVideoTypes: SearchVideoTypes = {
   video: 'EgIQAQ==',
   channel: 'EgIQAg==',
+  'channel-live': 'EgJAAQ==',
   playlist: 'EgIQAw==',
   movie: 'EgIQBA==',
   live: 'EgJAAQ=='

--- a/src/core/channelLive.ts
+++ b/src/core/channelLive.ts
@@ -4,7 +4,7 @@ import { defaultOptions, headers } from '../constants/default'
 import { fetch, isEmpty, sliceResults } from '../shared'
 import { extractVideoData, getSearchData } from '../parses'
 
-async function channelLive <T> (channelId: string, options: SearchOptions): Promise<Array<T>> {
+async function channelLive <T> (channelId: string, isLive: boolean, options: SearchOptions): Promise<Array<T>> {
   if (!channelId) {
     throw new Error('Channel id is empty')
   }
@@ -15,7 +15,8 @@ async function channelLive <T> (channelId: string, options: SearchOptions): Prom
     language = defaultOptions.language
   } = options
 
-  const channelUrl = new URL(`https://www.youtube.com/channel/${channelId}/videos?view=2&live_view=501&ucbcb=1`)
+  const liveCode = isLive ? '501' : '503'
+  const channelUrl = new URL(`https://www.youtube.com/channel/${channelId}/videos?view=2&live_view=${liveCode}&ucbcb=1`)
   const webPage = await fetch(channelUrl, {
     headers: {
       ...headers,
@@ -27,7 +28,10 @@ async function channelLive <T> (channelId: string, options: SearchOptions): Prom
 
   if (isEmpty(renderer)) return []
 
-  const resultsData = extractVideoData<T>(type, renderer)
+  const resultsData = extractVideoData<T>(type, renderer, {
+    channelId,
+    isLive
+  })
   const results = sliceResults<T>(resultsData, max)
 
   return results

--- a/src/core/channelLive.ts
+++ b/src/core/channelLive.ts
@@ -1,7 +1,7 @@
-import { URL } from 'url';
+import { URL } from 'url'
 import { SearchOptions } from '../types/shims'
 import { defaultOptions, headers } from '../constants/default'
-import { fetch, findByKey, isEmpty, sliceResults } from '../shared'
+import { fetch, isEmpty, sliceResults } from '../shared'
 import { extractVideoData, getSearchData } from '../parses'
 
 async function channelLive <T> (channelId: string, options: SearchOptions): Promise<Array<T>> {
@@ -15,8 +15,8 @@ async function channelLive <T> (channelId: string, options: SearchOptions): Prom
     language = defaultOptions.language
   } = options
 
-  let url = new URL(`https://m.youtube.com/channel/${channelId}/videos?view=2&live_view=501`);
-  const webPage = await fetch(url, {
+  const channelUrl = new URL(`https://www.youtube.com/channel/${channelId}/videos?view=2&live_view=501&ucbcb=1`)
+  const webPage = await fetch(channelUrl, {
     headers: {
       ...headers,
       'Accept-Language': language
@@ -33,4 +33,4 @@ async function channelLive <T> (channelId: string, options: SearchOptions): Prom
   return results
 }
 
-export default searchVideo
+export default channelLive

--- a/src/core/channelLive.ts
+++ b/src/core/channelLive.ts
@@ -1,0 +1,36 @@
+import { URL } from 'url';
+import { SearchOptions } from '../types/shims'
+import { defaultOptions, headers } from '../constants/default'
+import { fetch, findByKey, isEmpty, sliceResults } from '../shared'
+import { extractVideoData, getSearchData } from '../parses'
+
+async function channelLive <T> (channelId: string, options: SearchOptions): Promise<Array<T>> {
+  if (!channelId) {
+    throw new Error('Channel id is empty')
+  }
+
+  const {
+    type = defaultOptions.type,
+    max = defaultOptions.max,
+    language = defaultOptions.language
+  } = options
+
+  let url = new URL(`https://m.youtube.com/channel/${channelId}/videos?view=2&live_view=501`);
+  const webPage = await fetch(url, {
+    headers: {
+      ...headers,
+      'Accept-Language': language
+    }
+  })
+
+  const renderer = getSearchData(webPage, /var ytInitialData = (.*);<\/script>/)
+
+  if (isEmpty(renderer)) return []
+
+  const resultsData = extractVideoData<T>(type, renderer)
+  const results = sliceResults<T>(resultsData, max)
+
+  return results
+}
+
+export default searchVideo

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { Channel, ExtractData, Live, Music, Playlist, Video } from './types/data
 import { Options, SearchOptions } from './types/shims'
 import { defaultOptions } from './constants/default'
 import searchVideo from './core/searchVideo'
+import channelLive from './core/channelLive'
 import searchMusic from './core/searchMusic'
 
 const Options: Options = {
@@ -34,6 +35,15 @@ async function getChannel (query: string, options = Options): Promise<Array<Chan
   })
 
   return channels
+}
+
+async function getChannelLive (channelId: string, options = Options): Promise<Array<Live>> {
+  const lives = await channelLive<Live>(channelId, {
+    type: 'channel-live',
+    ...options
+  })
+
+  return lives
 }
 
 async function getMovie (query: string, options = Options): Promise<Array<Video>> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,6 +84,7 @@ export {
   getVideo,
   getPlaylist,
   getChannel,
+  getChannelLive,
   getMovie,
   getLive,
   getMusic,

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,16 @@ async function getChannel (query: string, options = Options): Promise<Array<Chan
 }
 
 async function getChannelLive (channelId: string, options = Options): Promise<Array<Live>> {
-  const lives = await channelLive<Live>(channelId, {
+  const lives = await channelLive<Live>(channelId, true, {
+    type: 'channel-live',
+    ...options
+  })
+
+  return lives
+}
+
+async function getChannelPastLive (channelId: string, options = Options): Promise<Array<Live>> {
+  const lives = await channelLive<Live>(channelId, false, {
     type: 'channel-live',
     ...options
   })
@@ -85,6 +94,7 @@ export {
   getPlaylist,
   getChannel,
   getChannelLive,
+  getChannelPastLive,
   getMovie,
   getLive,
   getMusic,

--- a/src/parses/parsesVideo.ts
+++ b/src/parses/parsesVideo.ts
@@ -10,6 +10,7 @@ export function extractVideoData <T> (type: string, data: ObjectType): Array<T> 
     if (type === 'video') return getVideoData(renderer?.videoRenderer)
     if (type === 'playlist') return getPlaylistData(renderer?.playlistRenderer)
     if (type === 'channel') return getChannelData(renderer?.channelRenderer)
+    if (type === 'channel-live') return getChannelLiveData(renderer?.channelRenderer)
     if (type === 'movie') return getVideoData(renderer?.videoRenderer)
     if (type === 'live') return getLiveData(renderer?.videoRenderer)
 
@@ -97,6 +98,25 @@ function getPlaylistVideoData (pRender: ObjectType): PlaylistVideo {
 }
 
 function getChannelData (cRender: ObjectType): Channel {
+  try {
+    const id = cRender?.channelId
+
+    const channelEndLink = findByKey('url', cRender.navigationEndpoint)
+    const channelLink = channelEndLink && `https://www.youtube.com${channelEndLink}`
+
+    return {
+      id,
+      type: 'channel',
+      name: getTitle(cRender, 'Name'),
+      verified: getChannelVerified(cRender),
+      link: channelLink || unknown('Link')
+    }
+  } catch (err) {
+    throw new Error('Error on get channel data')
+  }
+}
+
+function getChannelLiveData (cRender: ObjectType): Channel {
   try {
     const id = cRender?.channelId
 

--- a/src/types/data.ts
+++ b/src/types/data.ts
@@ -41,11 +41,14 @@ export interface Music {
   link: string
   videoLink: string
   channel: string
-  thumbnail: string,
+  thumbnail: string
   explicit: boolean
   type: SearchTypes
 }
 
-export type Live = Omit<Video, 'duration' | 'uploaded'>
+export type Live = Omit<Video, 'duration' | 'uploaded'> & {
+  live: boolean;
+}
+
 export type PlaylistVideo = Omit<Video, 'channel' | 'views' | 'uploaded' | 'type'>
 export type ExtractData = Video | Playlist | Channel | Live | Music | null

--- a/src/types/data.ts
+++ b/src/types/data.ts
@@ -46,6 +46,6 @@ export interface Music {
   type: SearchTypes
 }
 
-export type Live = Omit<Video, 'duration' | 'views' | 'uploaded'>
+export type Live = Omit<Video, 'duration' | 'uploaded'>
 export type PlaylistVideo = Omit<Video, 'channel' | 'views' | 'uploaded' | 'type'>
 export type ExtractData = Video | Playlist | Channel | Live | Music | null

--- a/src/types/shims.ts
+++ b/src/types/shims.ts
@@ -1,5 +1,6 @@
 export type SearchVideoType = 'video'
   | 'channel'
+  | 'channel-live'
   | 'playlist'
   | 'movie'
   | 'live'


### PR DESCRIPTION
I added two functions to get live and past live streams of a specific channel.

```js
const lives = await ytubes.getChannelLive('UCSJ4gkVC6NrvII8umztf0Ow')
const lives = await ytubes.getChannelPastLive('UCXBE_QQSZueB8082ml5fslg')
```

Also added live property to live type. and support for live viewers count.